### PR TITLE
Add static dashboard for drop catching monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Drop Catching Dashboard
+
+Ce mini-dashboard statique permet de surveiller une liste de noms de domaine en attente de drop catching. Il affiche des métriques synthétiques ainsi qu'un tableau filtrable.
+
+## Utilisation
+
+1. Lancez un serveur HTTP statique dans ce dossier, par exemple :
+   ```bash
+   python -m http.server 8000
+   ```
+2. Ouvrez ensuite <http://localhost:8000> dans votre navigateur.
+
+Les données affichées sont simulées. Adaptez le tableau `domains` dans `app.js` pour brancher vos propres données (API registrar, base SQL, etc.).

--- a/app.js
+++ b/app.js
@@ -1,0 +1,220 @@
+const domainTable = document.getElementById("domain-table");
+const watchCountEl = document.getElementById("watch-count");
+const criticalCountEl = document.getElementById("critical-count");
+const caughtCountEl = document.getElementById("caught-count");
+const searchInput = document.getElementById("search-input");
+const tldFilter = document.getElementById("tld-filter");
+const priorityFilter = document.getElementById("priority-filter");
+const emptyState = document.getElementById("empty-state");
+
+const domains = [
+  {
+    name: "superapp",
+    tld: ".fr",
+    priority: "high",
+    expiry: "2023-10-04T10:30:00Z",
+    dropWindow: "2023-10-05T10:45:00Z",
+    status: "pending",
+  },
+  {
+    name: "fastdelivery",
+    tld: ".com",
+    priority: "medium",
+    expiry: "2023-10-03T07:00:00Z",
+    dropWindow: "2023-10-04T07:15:00Z",
+    status: "pending",
+  },
+  {
+    name: "techwave",
+    tld: ".io",
+    priority: "high",
+    expiry: "2023-10-02T20:00:00Z",
+    dropWindow: "2023-10-03T20:05:00Z",
+    status: "caught",
+  },
+  {
+    name: "greenenergy",
+    tld: ".fr",
+    priority: "low",
+    expiry: "2023-10-01T13:30:00Z",
+    dropWindow: "2023-10-02T13:45:00Z",
+    status: "expired",
+  },
+  {
+    name: "cryptobuzz",
+    tld: ".xyz",
+    priority: "medium",
+    expiry: "2023-10-04T23:55:00Z",
+    dropWindow: "2023-10-05T00:10:00Z",
+    status: "pending",
+  },
+  {
+    name: "smartcontract",
+    tld: ".eth",
+    priority: "high",
+    expiry: "2023-10-04T18:00:00Z",
+    dropWindow: "2023-10-04T18:30:00Z",
+    status: "pending",
+  },
+  {
+    name: "boutiqueparis",
+    tld: ".shop",
+    priority: "low",
+    expiry: "2023-10-06T09:00:00Z",
+    dropWindow: "2023-10-06T09:10:00Z",
+    status: "pending",
+  },
+  {
+    name: "metaversehub",
+    tld: ".net",
+    priority: "medium",
+    expiry: "2023-10-02T11:20:00Z",
+    dropWindow: "2023-10-03T11:20:00Z",
+    status: "expired",
+  },
+];
+
+const formatDate = (isoString) => {
+  const date = new Date(isoString);
+  return date.toLocaleString("fr-FR", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+};
+
+const diffFromNow = (isoString) => {
+  const now = Date.now();
+  const target = new Date(isoString).getTime();
+  const diff = target - now;
+  const absDiff = Math.abs(diff);
+  const minutes = Math.floor(absDiff / 60000);
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+
+  const formatted = `${hours}h ${remainingMinutes.toString().padStart(2, "0")}m`;
+  return {
+    formatted,
+    isPast: diff < 0,
+    isCritical: diff > 0 && diff <= 60 * 60 * 1000,
+  };
+};
+
+const renderFilters = () => {
+  const uniqueTlds = [
+    "all",
+    ...new Set(domains.map((domain) => domain.tld).sort()),
+  ];
+  uniqueTlds.forEach((tld) => {
+    if (tld === "all") return;
+    const option = document.createElement("option");
+    option.value = tld;
+    option.textContent = tld;
+    tldFilter.appendChild(option);
+  });
+};
+
+const renderTable = () => {
+  const filters = {
+    search: searchInput.value.trim().toLowerCase(),
+    tld: tldFilter.value,
+    priority: priorityFilter.value,
+  };
+
+  domainTable.innerHTML = "";
+
+  const filteredDomains = domains.filter((domain) => {
+    const matchesSearch = `${domain.name}${domain.tld}`
+      .toLowerCase()
+      .includes(filters.search);
+    const matchesTld =
+      filters.tld === "all" || domain.tld.toLowerCase() === filters.tld;
+    const matchesPriority =
+      filters.priority === "all" || domain.priority === filters.priority;
+    return matchesSearch && matchesTld && matchesPriority;
+  });
+
+  emptyState.hidden = filteredDomains.length !== 0;
+
+  filteredDomains
+    .sort((a, b) => new Date(a.dropWindow) - new Date(b.dropWindow))
+    .forEach((domain) => {
+      const row = document.createElement("tr");
+
+      const domainCell = document.createElement("td");
+      domainCell.textContent = `${domain.name}${domain.tld}`;
+
+      const tldCell = document.createElement("td");
+      tldCell.textContent = domain.tld;
+
+      const priorityCell = document.createElement("td");
+      const badge = document.createElement("span");
+      badge.className = `priority ${domain.priority}`;
+      const labels = {
+        high: "Haute",
+        medium: "Moyenne",
+        low: "Basse",
+      };
+      badge.textContent = labels[domain.priority];
+      priorityCell.appendChild(badge);
+
+      const expiryCell = document.createElement("td");
+      expiryCell.textContent = formatDate(domain.expiry);
+
+      const dropCell = document.createElement("td");
+      const diff = diffFromNow(domain.dropWindow);
+      dropCell.textContent = `${formatDate(domain.dropWindow)} (${diff.formatted})`;
+
+      const statusCell = document.createElement("td");
+      statusCell.className = `status ${domain.status}`;
+      const statusLabel = {
+        pending: diff.isPast ? "En retard" : "En attente",
+        caught: "Catch réussi",
+        expired: "Expiré",
+      };
+      statusCell.textContent = statusLabel[domain.status] ?? domain.status;
+
+      if (domain.status === "pending" && diff.isPast) {
+        statusCell.classList.replace("pending", "expired");
+      }
+
+      row.append(
+        domainCell,
+        tldCell,
+        priorityCell,
+        expiryCell,
+        dropCell,
+        statusCell
+      );
+      domainTable.appendChild(row);
+    });
+};
+
+const updateMetrics = () => {
+  const now = Date.now();
+  const watch = domains.filter((domain) => domain.status === "pending");
+  const critical = watch.filter((domain) => {
+    const dropTime = new Date(domain.dropWindow).getTime();
+    const diff = dropTime - now;
+    return diff > 0 && diff <= 60 * 60 * 1000;
+  });
+  const caught = domains.filter((domain) => domain.status === "caught");
+
+  watchCountEl.textContent = watch.length;
+  criticalCountEl.textContent = critical.length;
+  caughtCountEl.textContent = caught.length;
+};
+
+const refresh = () => {
+  renderTable();
+  updateMetrics();
+};
+
+renderFilters();
+refresh();
+
+searchInput.addEventListener("input", refresh);
+[tldFilter, priorityFilter].forEach((element) =>
+  element.addEventListener("change", refresh)
+);
+
+setInterval(refresh, 30_000);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Drop Catching Dashboard</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Drop Catching - Monitoring des NDD</h1>
+      <div class="filters">
+        <label>
+          Recherche
+          <input type="search" id="search-input" placeholder="Rechercher un domaine" />
+        </label>
+        <label>
+          Extension
+          <select id="tld-filter">
+            <option value="all">Toutes</option>
+          </select>
+        </label>
+        <label>
+          Priorité
+          <select id="priority-filter">
+            <option value="all">Toutes</option>
+            <option value="high">Haute</option>
+            <option value="medium">Moyenne</option>
+            <option value="low">Basse</option>
+          </select>
+        </label>
+      </div>
+    </header>
+
+    <main>
+      <section class="metrics">
+        <article>
+          <h2>À surveiller</h2>
+          <p id="watch-count">0</p>
+        </article>
+        <article>
+          <h2>Fenêtre critique (&lt; 1h)</h2>
+          <p id="critical-count">0</p>
+        </article>
+        <article>
+          <h2>Catches réussis</h2>
+          <p id="caught-count">0</p>
+        </article>
+      </section>
+
+      <section class="board">
+        <table>
+          <thead>
+            <tr>
+              <th>Domaine</th>
+              <th>Extension</th>
+              <th>Priorité</th>
+              <th>Date d'expiration</th>
+              <th>Fenêtre drop</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody id="domain-table"></tbody>
+        </table>
+        <div class="empty-state" id="empty-state" hidden>
+          <p>Aucun domaine ne correspond à vos filtres.</p>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <p>
+        Mise à jour en temps réel simulée – adaptez ce dashboard avec vos
+        données d'enregistrement pour le drop catching.
+      </p>
+    </footer>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,210 @@
+:root {
+  color-scheme: dark light;
+  --bg: #0f172a;
+  --card: rgba(15, 23, 42, 0.72);
+  --accent: #38bdf8;
+  --accent-strong: #0284c7;
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --success: #22c55e;
+  --warning: #facc15;
+  --danger: #f87171;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #1e293b, var(--bg));
+  color: var(--text);
+  display: flex;
+  flex-direction: column;
+}
+
+header {
+  padding: 2.5rem 3rem 1rem;
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.2), transparent);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+header h1 {
+  margin: 0 0 1.5rem;
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  font-weight: 700;
+}
+
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.filters label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.85rem;
+  color: var(--muted);
+  gap: 0.35rem;
+}
+
+.filters input,
+.filters select {
+  padding: 0.65rem 0.8rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--text);
+  min-width: 12rem;
+}
+
+main {
+  flex: 1;
+  padding: 2rem 3rem 3.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.5rem;
+}
+
+.metrics article {
+  padding: 1.5rem;
+  border-radius: 1rem;
+  background: var(--card);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.metrics h2 {
+  margin: 0 0 0.75rem;
+  font-size: 1.05rem;
+  color: var(--muted);
+}
+
+.metrics p {
+  margin: 0;
+  font-size: 2.5rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.board {
+  background: rgba(15, 23, 42, 0.5);
+  border-radius: 1.25rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  overflow: hidden;
+  box-shadow: 0 30px 60px -30px rgba(15, 23, 42, 0.9);
+  backdrop-filter: blur(12px);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+thead {
+  background: rgba(148, 163, 184, 0.12);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 0.75rem;
+}
+
+thead th {
+  padding: 0.9rem 1.2rem;
+  text-align: left;
+  color: var(--muted);
+}
+
+tbody td {
+  padding: 1.2rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.1);
+  font-size: 0.95rem;
+}
+
+tbody tr:hover {
+  background: rgba(14, 165, 233, 0.08);
+}
+
+.priority {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.priority.high {
+  background: rgba(248, 113, 113, 0.16);
+  color: var(--danger);
+}
+
+.priority.medium {
+  background: rgba(250, 204, 21, 0.16);
+  color: var(--warning);
+}
+
+.priority.low {
+  background: rgba(34, 197, 94, 0.16);
+  color: var(--success);
+}
+
+.status {
+  font-weight: 600;
+}
+
+.status.caught {
+  color: var(--success);
+}
+
+.status.pending {
+  color: var(--warning);
+}
+
+.status.expired {
+  color: var(--danger);
+}
+
+.empty-state {
+  padding: 2rem;
+  text-align: center;
+  color: var(--muted);
+}
+
+footer {
+  text-align: center;
+  padding: 1.5rem;
+  color: var(--muted);
+  font-size: 0.85rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.15);
+  background: rgba(15, 23, 42, 0.6);
+}
+
+@media (max-width: 768px) {
+  header,
+  main {
+    padding-left: 1.2rem;
+    padding-right: 1.2rem;
+  }
+
+  .filters input,
+  .filters select {
+    min-width: unset;
+  }
+
+  tbody td,
+  thead th {
+    padding: 0.85rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a static HTML dashboard to monitor domain names for drop catching
- style the interface with a modern glassmorphism-inspired layout and responsive design
- implement simulated data, filtering and live metric refresh in vanilla JavaScript and document usage instructions

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68dc4d3a36fc83278d870b32bb7b2bb6